### PR TITLE
Move operation has no value

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.flipkart.zjsonpatch</groupId>
     <artifactId>zjsonpatch</artifactId>
-    <version>0.2.0</version>
+    <version>0.2.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>zjsonpatch</name>

--- a/src/main/java/com/flipkart/zjsonpatch/JsonDiff.java
+++ b/src/main/java/com/flipkart/zjsonpatch/JsonDiff.java
@@ -165,7 +165,7 @@ public class JsonDiff {
             jsonNode.put(Constants.FROM, getArrayNodeRepresentation(diff.getPath())); //required {from} only in case of Move Operation
             jsonNode.put(Constants.PATH, getArrayNodeRepresentation(diff.getToPath()));  // destination Path
         }
-        if (!Operation.REMOVE.equals(diff.getOperation())) { // setting only for Non-Remove operation
+        if (!Operation.REMOVE.equals(diff.getOperation()) && !Operation.MOVE.equals(diff.getOperation())) { // setting only for Non-Remove operation
             jsonNode.put(Constants.VALUE, diff.getValue());
         }
         return jsonNode;

--- a/src/test/java/com/flipkart/zjsonpatch/MoveOperationTest.java
+++ b/src/test/java/com/flipkart/zjsonpatch/MoveOperationTest.java
@@ -1,6 +1,16 @@
 package com.flipkart.zjsonpatch;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import org.hamcrest.core.Is;
+import org.junit.Assert;
+import org.junit.Test;
+
 import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
 
 /**
  * @author ctranxuan (streamdata.io).
@@ -8,5 +18,27 @@ import java.io.IOException;
 public class MoveOperationTest extends AbstractTest {
     public MoveOperationTest() throws IOException {
         super("move");
+    }
+
+    @Test
+    public void testMoveValueGeneratedHasNoValue() throws IOException {
+        JsonNode jsonNode1 = objectMapper.readTree("{ \"foo\": { \"bar\": \"baz\", \"waldo\": \"fred\" }, \"qux\": { \"corge\": \"grault\" } }");
+        JsonNode jsonNode2 = objectMapper.readTree("{ \"foo\": { \"bar\": \"baz\" }, \"qux\": { \"corge\": \"grault\", \"thud\": \"fred\" } }");
+        JsonNode patch = objectMapper.readTree("[{\"op\":\"move\",\"from\":\"/foo/waldo\",\"path\":\"/qux/thud\"}]");
+
+        JsonNode diff = JsonDiff.asJson(jsonNode1, jsonNode2);
+
+        assertThat(diff, equalTo(patch));
+    }
+
+    @Test
+    public void testMoveArrayGeneratedHasNoValue() throws IOException {
+        JsonNode jsonNode1 = objectMapper.readTree("{ \"foo\": [ \"all\", \"grass\", \"cows\", \"eat\" ] }");
+        JsonNode jsonNode2 = objectMapper.readTree("{ \"foo\": [ \"all\", \"cows\", \"eat\", \"grass\" ] }");
+        JsonNode patch = objectMapper.readTree("[{\"op\":\"move\",\"from\":\"/foo/1\",\"path\":\"/foo/3\"}]");
+
+        JsonNode diff = JsonDiff.asJson(jsonNode1, jsonNode2);
+
+        assertThat(diff, equalTo(patch));
     }
 }


### PR DESCRIPTION
Hello again,
We've just noticed that the move operation should have no value as per rfc6902. 
Currently, zjsonpatch generates:

`[{"op":"move","path":"/qux/thud","from":"/foo/waldo","value":"fred"}]`

while according to the rfc6902, it should be:

`[{"op":"move","from":"/foo/waldo","path":"/qux/thud"}]`

This PR should fix the issue. Additionnal unit tests have been added (based on the examples of the appendix of the rfc).

Sorry not having seen this in the previous PR... 
Thanks in advance!

[Streamdata.io](http://streamdata.io/) team.



