### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/src/main/java/com/flipkart/zjsonpatch/Constants.java
+++ b/src/main/java/com/flipkart/zjsonpatch/Constants.java
@@ -11,4 +11,7 @@ class Constants {
     public static String VALUE = "value";
     public static String PATH = "path";
     public static String FROM = "from";
+
+    private Constants() {}
+
 }

--- a/src/main/java/com/flipkart/zjsonpatch/JsonDiff.java
+++ b/src/main/java/com/flipkart/zjsonpatch/JsonDiff.java
@@ -21,6 +21,8 @@ public class JsonDiff {
 
     public static final EncodePathFunction ENCODE_PATH_FUNCTION = new EncodePathFunction();
 
+    private JsonDiff() {}
+
     private final static class EncodePathFunction implements Function<Object, String> {
         @Override
         public String apply(Object object) {

--- a/src/main/java/com/flipkart/zjsonpatch/JsonPatch.java
+++ b/src/main/java/com/flipkart/zjsonpatch/JsonPatch.java
@@ -20,6 +20,8 @@ public class JsonPatch {
 
     private static final DecodePathFunction DECODE_PATH_FUNCTION = new DecodePathFunction();
 
+    private JsonPatch() {}
+
     private final static class DecodePathFunction implements Function<String, String> {
         @Override
         public String apply(String path) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118

Please let me know if you have any questions.

M-Ezzat