### PR TITLE
Added JSON Patch payload validation API + refactoring

### DIFF
--- a/src/main/java/com/flipkart/zjsonpatch/ApplyProcessor.java
+++ b/src/main/java/com/flipkart/zjsonpatch/ApplyProcessor.java
@@ -1,0 +1,144 @@
+package com.flipkart.zjsonpatch;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.base.Strings;
+
+import java.util.List;
+
+class ApplyProcessor implements JsonPatchProcessor {
+
+    private JsonNode target;
+
+    ApplyProcessor(JsonNode target) {
+        this.target = target.deepCopy();
+    }
+
+    public JsonNode result() {
+        return target;
+    }
+
+    public void move(List<String> fromPath, List<String> toPath) {
+        JsonNode parentNode = getParentNode(fromPath);
+        String field = fromPath.get(fromPath.size() - 1).replaceAll("\"", "");
+        JsonNode valueNode =  parentNode.isArray() ? parentNode.get(Integer.parseInt(field)) : parentNode.get(field);
+        remove(fromPath);
+        add(toPath, valueNode);
+    }
+
+    public void add(List<String> path, JsonNode value) {
+        if (path.isEmpty()) {
+            throw new JsonPatchApplicationException("[ADD Operation] path is empty , path : ");
+        } else {
+            JsonNode parentNode = getParentNode(path);
+            if (parentNode == null) {
+                throw new JsonPatchApplicationException("[ADD Operation] noSuchPath in source, path provided : " + path);
+            } else {
+                String fieldToReplace = path.get(path.size() - 1).replaceAll("\"", "");
+                if (fieldToReplace.equals("") && path.size() == 1)
+                    target = value;
+                else if (!parentNode.isContainerNode())
+                    throw new JsonPatchApplicationException("[ADD Operation] parent is not a container in source, path provided : " + path + " | node : " + parentNode);
+                else if (parentNode.isArray())
+                    addToArray(path, value, parentNode);
+                else
+                    addToObject(path, parentNode, value);
+            }
+        }
+    }
+
+    private void addToObject(List<String> path, JsonNode node, JsonNode value) {
+        final ObjectNode target = (ObjectNode) node;
+        String key = path.get(path.size() - 1).replaceAll("\"", "");
+        target.put(key, value);
+    }
+
+    private void addToArray(List<String> path, JsonNode value, JsonNode parentNode) {
+        final ArrayNode target = (ArrayNode) parentNode;
+        String idxStr = path.get(path.size() - 1);
+
+        if ("-".equals(idxStr)) {
+            // see http://tools.ietf.org/html/rfc6902#section-4.1
+            target.add(value);
+        } else {
+            Integer idx = Integer.parseInt(idxStr.replaceAll("\"", ""));
+            if (idx < target.size()) {
+                target.insert(idx, value);
+            } else {
+                if (idx == target.size()) {
+                    target.add(value);
+                } else {
+                    throw new JsonPatchApplicationException("[ADD Operation] [addToArray] index Out of bound, index provided is higher than allowed, path " + path);
+                }
+            }
+        }
+    }
+
+    public void replace(List<String> path, JsonNode value) {
+        if (path.isEmpty()) {
+            throw new JsonPatchApplicationException("[Replace Operation] path is empty");
+        } else {
+            JsonNode parentNode = getParentNode(path);
+            if (parentNode == null) {
+                throw new JsonPatchApplicationException("[Replace Operation] noSuchPath in source, path provided : " + path);
+            } else {
+                String fieldToReplace = path.get(path.size() - 1).replaceAll("\"", "");
+                if (Strings.isNullOrEmpty(fieldToReplace) && path.size() == 1)
+                    target = value;
+                else if (parentNode.isObject())
+                    ((ObjectNode) parentNode).put(fieldToReplace, value);
+                else if (parentNode.isArray())
+                    ((ArrayNode) parentNode).set(Integer.parseInt(fieldToReplace), value);
+                else
+                    throw new JsonPatchApplicationException("[Replace Operation] noSuchPath in source, path provided : " + path);
+            }
+        }
+    }
+
+    public void remove(List<String> path) {
+        if (path.isEmpty()) {
+            throw new JsonPatchApplicationException("[Remove Operation] path is empty");
+        } else {
+            JsonNode parentNode = getParentNode(path);
+            if (parentNode == null) {
+                throw new JsonPatchApplicationException("[Remove Operation] noSuchPath in source, path provided : " + path);
+            } else {
+                String fieldToRemove = path.get(path.size() - 1).replaceAll("\"", "");
+                if (parentNode.isObject())
+                    ((ObjectNode) parentNode).remove(fieldToRemove);
+                else if (parentNode.isArray())
+                    ((ArrayNode) parentNode).remove(Integer.parseInt(fieldToRemove));
+                else
+                    throw new JsonPatchApplicationException("[Remove Operation] noSuchPath in source, path provided : " + path);
+            }
+        }
+    }
+
+    private JsonNode getParentNode(List<String> fromPath) {
+        List<String> pathToParent = fromPath.subList(0, fromPath.size() - 1); // would never by out of bound, lets see
+        return getNode(target, pathToParent, 1);
+    }
+
+    private JsonNode getNode(JsonNode ret, List<String> path, int pos) {
+        if (pos >= path.size()) {
+            return ret;
+        }
+        String key = path.get(pos);
+        if (ret.isArray()) {
+            int keyInt = Integer.parseInt(key.replaceAll("\"", ""));
+            JsonNode element = ret.get(keyInt);
+            if (element == null)
+                return null;
+            else
+                return getNode(ret.get(keyInt), path, ++pos);
+        } else if (ret.isObject()) {
+            if (ret.has(key)) {
+                return getNode(ret.get(key), path, ++pos);
+            }
+            return null;
+        } else {
+            return ret;
+        }
+    }
+}

--- a/src/main/java/com/flipkart/zjsonpatch/CompatibilityFlags.java
+++ b/src/main/java/com/flipkart/zjsonpatch/CompatibilityFlags.java
@@ -1,10 +1,14 @@
 package com.flipkart.zjsonpatch;
 
+import java.util.EnumSet;
+
 /**
  * Created by tomerga on 04/09/2016.
  */
-public class CompatibilityFlags {
-    public static int MISSING_VALUES_AS_NULLS = 1;
+public enum CompatibilityFlags {
+    MISSING_VALUES_AS_NULLS;
 
-    public static int DEFAULTS = 0;
+    public static EnumSet<CompatibilityFlags> defaults() {
+        return EnumSet.noneOf(CompatibilityFlags.class);
+    }
 }

--- a/src/main/java/com/flipkart/zjsonpatch/CompatibilityFlags.java
+++ b/src/main/java/com/flipkart/zjsonpatch/CompatibilityFlags.java
@@ -1,0 +1,10 @@
+package com.flipkart.zjsonpatch;
+
+/**
+ * Created by tomerga on 04/09/2016.
+ */
+public class CompatibilityFlags {
+    public static int MISSING_VALUES_AS_NULLS = 1;
+
+    public static int DEFAULTS = 0;
+}

--- a/src/main/java/com/flipkart/zjsonpatch/JsonPatch.java
+++ b/src/main/java/com/flipkart/zjsonpatch/JsonPatch.java
@@ -33,7 +33,7 @@ public final class JsonPatch {
         return child;
     }
 
-    private static void process(JsonNode patch, JsonPatchProcessor processor)
+    private static void process(JsonNode patch, JsonPatchProcessor processor, int compatibilityFlags)
             throws InvalidJsonPatchException {
 
         if (!patch.isArray())
@@ -70,14 +70,22 @@ public final class JsonPatch {
         }
     }
 
+    public static void validate(JsonNode patch, int compatibilityFlags) throws InvalidJsonPatchException {
+        process(patch, NoopProcessor.INSTANCE, compatibilityFlags);
+    }
+
     public static void validate(JsonNode patch) throws InvalidJsonPatchException {
-        process(patch, NoopProcessor.INSTANCE);
+        validate(patch, CompatibilityFlags.DEFAULTS);
+    }
+
+    public static JsonNode apply(JsonNode patch, JsonNode source, int compatibilityFlags) throws JsonPatchApplicationException {
+        ApplyProcessor processor = new ApplyProcessor(source);
+        process(patch, processor, compatibilityFlags);
+        return processor.result();
     }
 
     public static JsonNode apply(JsonNode patch, JsonNode source) throws JsonPatchApplicationException {
-        ApplyProcessor processor = new ApplyProcessor(source);
-        process(patch, processor);
-        return processor.result();
+        return apply(patch, source, CompatibilityFlags.DEFAULTS);
     }
 
     private static List<String> getPath(JsonNode path) {

--- a/src/main/java/com/flipkart/zjsonpatch/JsonPatch.java
+++ b/src/main/java/com/flipkart/zjsonpatch/JsonPatch.java
@@ -11,6 +11,8 @@ import com.google.common.collect.Lists;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.Spliterator;
+import java.util.function.Consumer;
 
 /**
  * User: gopi.vishwakarma
@@ -29,7 +31,7 @@ public final class JsonPatch {
         }
     }
 
-    private final static JsonNode getPatchAttr(JsonNode jsonNode, String attr) {
+    private static JsonNode getPatchAttr(JsonNode jsonNode, String attr) {
         JsonNode child = jsonNode.get(attr);
         if (child == null)
             throw new InvalidJsonPatchException("Invalid JSON Patch payload (missing '" + attr + "' field)");
@@ -37,6 +39,8 @@ public final class JsonPatch {
     }
 
     public static JsonNode apply(JsonNode patch, JsonNode source) {
+        if (!patch.isArray())
+            throw new InvalidJsonPatchException("Invalid JSON Patch payload (not an array)");
         Iterator<JsonNode> operations = patch.iterator();
         JsonNode ret = source.deepCopy();
         while (operations.hasNext()) {

--- a/src/main/java/com/flipkart/zjsonpatch/JsonPatch.java
+++ b/src/main/java/com/flipkart/zjsonpatch/JsonPatch.java
@@ -70,6 +70,10 @@ public final class JsonPatch {
         }
     }
 
+    public static void validate(JsonNode patch) throws InvalidJsonPatchException {
+        process(patch, NoopProcessor.INSTANCE);
+    }
+
     public static JsonNode apply(JsonNode patch, JsonNode source) throws JsonPatchApplicationException {
         ApplyProcessor processor = new ApplyProcessor(source);
         process(patch, processor);

--- a/src/main/java/com/flipkart/zjsonpatch/JsonPatch.java
+++ b/src/main/java/com/flipkart/zjsonpatch/JsonPatch.java
@@ -1,18 +1,13 @@
 package com.flipkart.zjsonpatch;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Function;
 import com.google.common.base.Splitter;
-import com.google.common.base.Strings;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 
 import java.util.Iterator;
 import java.util.List;
-import java.util.Spliterator;
-import java.util.function.Consumer;
 
 /**
  * User: gopi.vishwakarma
@@ -38,11 +33,12 @@ public final class JsonPatch {
         return child;
     }
 
-    public static JsonNode apply(JsonNode patch, JsonNode source) {
+    private static void process(JsonNode patch, JsonPatchProcessor processor)
+            throws InvalidJsonPatchException {
+
         if (!patch.isArray())
             throw new InvalidJsonPatchException("Invalid JSON Patch payload (not an array)");
         Iterator<JsonNode> operations = patch.iterator();
-        JsonNode ret = source.deepCopy();
         while (operations.hasNext()) {
             JsonNode jsonNode = operations.next();
             if (!jsonNode.isObject()) throw new InvalidJsonPatchException("Invalid JSON Patch payload (not an object)");
@@ -59,150 +55,25 @@ public final class JsonPatch {
 
             switch (operation) {
                 case REMOVE:
-                    remove(ret, path);
+                    processor.remove(path);
                     break;
                 case REPLACE:
-                    ret = replace(ret, path, value);
+                    processor.replace(path, value);
                     break;
                 case ADD:
-                    ret = add(ret, path, value);
+                    processor.add(path, value);
                     break;
                 case MOVE:
-                    ret = move(ret, fromPath, path);
+                    processor.move(fromPath, path);
                     break;
             }
         }
-        return ret;
     }
 
-    private static JsonNode move(JsonNode node, List<String> fromPath, List<String> toPath) {
-        JsonNode parentNode = getParentNode(node, fromPath);
-        String field = fromPath.get(fromPath.size() - 1).replaceAll("\"", "");
-        JsonNode valueNode =  parentNode.isArray() ? parentNode.get(Integer.parseInt(field)) : parentNode.get(field);
-        remove(node, fromPath);
-        return add(node, toPath, valueNode);
-    }
-
-    private static JsonNode add(JsonNode node, List<String> path, JsonNode value) {
-        if (path.isEmpty()) {
-            throw new JsonPatchApplicationException("[ADD Operation] path is empty , path : ");
-        } else {
-            JsonNode parentNode = getParentNode(node, path);
-            if (parentNode == null) {
-                throw new JsonPatchApplicationException("[ADD Operation] noSuchPath in source, path provided : " + path);
-            } else {
-                String fieldToReplace = path.get(path.size() - 1).replaceAll("\"", "");
-                if (fieldToReplace.equals("") && path.size() == 1) {
-                    return value;
-                }
-                if (!parentNode.isContainerNode()) {
-                    throw new JsonPatchApplicationException("[ADD Operation] parent is not a container in source, path provided : " + path + " | node : " + parentNode);
-                } else {
-                    if (parentNode.isArray()) {
-                        addToArray(path, value, parentNode);
-                    } else {
-                        addToObject(path, parentNode, value);
-                    }
-                }
-            }
-        }
-        return node;
-    }
-
-    private static void addToObject(List<String> path, JsonNode node, JsonNode value) {
-        final ObjectNode target = (ObjectNode) node;
-        String key = path.get(path.size() - 1).replaceAll("\"", "");
-        target.put(key, value);
-    }
-
-    private static void addToArray(List<String> path, JsonNode value, JsonNode parentNode) {
-        final ArrayNode target = (ArrayNode) parentNode;
-        String idxStr = path.get(path.size() - 1);
-
-        if ("-".equals(idxStr)) {
-            // see http://tools.ietf.org/html/rfc6902#section-4.1
-            target.add(value);
-        } else {
-            Integer idx = Integer.parseInt(idxStr.replaceAll("\"", ""));
-            if (idx < target.size()) {
-                target.insert(idx, value);
-            } else {
-                if (idx == target.size()) {
-                    target.add(value);
-                } else {
-                    throw new JsonPatchApplicationException("[ADD Operation] [addToArray] index Out of bound, index provided is higher than allowed, path " + path);
-                }
-            }
-        }
-    }
-
-    private static JsonNode replace(JsonNode node, List<String> path, JsonNode value) {
-        if (path.isEmpty()) {
-            throw new JsonPatchApplicationException("[Replace Operation] path is empty");
-        } else {
-            JsonNode parentNode = getParentNode(node, path);
-            if (parentNode == null) {
-                throw new JsonPatchApplicationException("[Replace Operation] noSuchPath in source, path provided : " + path);
-            } else {
-                String fieldToReplace = path.get(path.size() - 1).replaceAll("\"", "");
-                if (Strings.isNullOrEmpty(fieldToReplace) && path.size() == 1) {
-                    return value;
-                }
-                if (parentNode.isObject())
-                    ((ObjectNode) parentNode).put(fieldToReplace, value);
-                else if (parentNode.isArray())
-                    ((ArrayNode) parentNode).set(Integer.parseInt(fieldToReplace), value);
-                else
-                    throw new JsonPatchApplicationException("[Replace Operation] noSuchPath in source, path provided : " + path);
-            }
-            return node;
-        }
-    }
-
-    private static void remove(JsonNode node, List<String> path) {
-        if (path.isEmpty()) {
-            throw new JsonPatchApplicationException("[Remove Operation] path is empty");
-        } else {
-            JsonNode parentNode = getParentNode(node, path);
-            if (parentNode == null) {
-                throw new JsonPatchApplicationException("[Remove Operation] noSuchPath in source, path provided : " + path);
-            } else {
-                String fieldToRemove = path.get(path.size() - 1).replaceAll("\"", "");
-                if (parentNode.isObject())
-                    ((ObjectNode) parentNode).remove(fieldToRemove);
-                else if (parentNode.isArray())
-                    ((ArrayNode) parentNode).remove(Integer.parseInt(fieldToRemove));
-                else
-                    throw new JsonPatchApplicationException("[Remove Operation] noSuchPath in source, path provided : " + path);
-            }
-        }
-    }
-
-    private static JsonNode getParentNode(JsonNode node, List<String> fromPath) {
-        List<String> pathToParent = fromPath.subList(0, fromPath.size() - 1); // would never by out of bound, lets see
-        return getNode(node, pathToParent, 1);
-    }
-
-    private static JsonNode getNode(JsonNode ret, List<String> path, int pos) {
-        if (pos >= path.size()) {
-            return ret;
-        }
-        String key = path.get(pos);
-        if (ret.isArray()) {
-            int keyInt = Integer.parseInt(key.replaceAll("\"", ""));
-            JsonNode element = ret.get(keyInt);
-            if (element == null)
-                return null;
-            else
-                return getNode(ret.get(keyInt), path, ++pos);
-        } else if (ret.isObject()) {
-            if (ret.has(key)) {
-                return getNode(ret.get(key), path, ++pos);
-            }
-            return null;
-        } else {
-            return ret;
-        }
+    public static JsonNode apply(JsonNode patch, JsonNode source) throws JsonPatchApplicationException {
+        ApplyProcessor processor = new ApplyProcessor(source);
+        process(patch, processor);
+        return processor.result();
     }
 
     private static List<String> getPath(JsonNode path) {

--- a/src/main/java/com/flipkart/zjsonpatch/JsonPatchProcessor.java
+++ b/src/main/java/com/flipkart/zjsonpatch/JsonPatchProcessor.java
@@ -1,0 +1,12 @@
+package com.flipkart.zjsonpatch;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.util.List;
+
+interface JsonPatchProcessor {
+    void remove(List<String> path);
+    void replace(List<String> path, JsonNode value);
+    void add(List<String> path, JsonNode value);
+    void move(List<String> fromPath, List<String> toPath);
+}

--- a/src/main/java/com/flipkart/zjsonpatch/NoopProcessor.java
+++ b/src/main/java/com/flipkart/zjsonpatch/NoopProcessor.java
@@ -1,0 +1,18 @@
+package com.flipkart.zjsonpatch;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.util.List;
+
+/** A JSON patch processor that does nothing, intended for testing and validation. */
+public class NoopProcessor implements JsonPatchProcessor {
+    static NoopProcessor INSTANCE;
+    static {
+        INSTANCE = new NoopProcessor();
+    }
+
+    @Override public void remove(List<String> path) {}
+    @Override public void replace(List<String> path, JsonNode value) {}
+    @Override public void add(List<String> path, JsonNode value) {}
+    @Override public void move(List<String> fromPath, List<String> toPath) {}
+}

--- a/src/main/java/com/flipkart/zjsonpatch/Operation.java
+++ b/src/main/java/com/flipkart/zjsonpatch/Operation.java
@@ -4,8 +4,6 @@ import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 /**
  * User: gopi.vishwakarma
  * Date: 30/07/14
@@ -29,9 +27,11 @@ enum Operation {
         this.rfcName = rfcName;
     }
 
-    public static Operation fromRfcName(String rfcName) {
-        checkNotNull(rfcName, "rfcName cannot be null");
-        return checkNotNull(OPS.get(rfcName.toLowerCase()), "unknown / unsupported operation %s", rfcName);
+    public static Operation fromRfcName(String rfcName) throws InvalidJsonPatchException {
+        if (rfcName == null) throw new InvalidJsonPatchException("rfcName cannot be null");
+        Operation op = OPS.get(rfcName.toLowerCase());
+        if (op == null) throw new InvalidJsonPatchException("unknown / unsupported operation " + rfcName);
+        return op;
     }
 
     public String rfcName() {

--- a/src/test/java/com/flipkart/zjsonpatch/AbstractTest.java
+++ b/src/test/java/com/flipkart/zjsonpatch/AbstractTest.java
@@ -16,9 +16,9 @@ import static org.hamcrest.core.IsEqual.equalTo;
  * @author ctranxuan (streamdata.io).
  */
 public abstract class AbstractTest {
-    static ObjectMapper objectMapper = new ObjectMapper();
-    static ArrayNode jsonNode;
-    static ArrayNode errorNode;
+    ObjectMapper objectMapper = new ObjectMapper();
+    ArrayNode jsonNode;
+    ArrayNode errorNode;
 
     protected AbstractTest(String fileName) throws IOException {
         String path = "/testdata/" + fileName + ".json";

--- a/src/test/java/com/flipkart/zjsonpatch/ApiTest.java
+++ b/src/test/java/com/flipkart/zjsonpatch/ApiTest.java
@@ -11,11 +11,18 @@ import java.io.IOException;
  * Date: 03/08/16
  */
 public class ApiTest {
-
     @Test(expected = InvalidJsonPatchException.class)
-    public void applyingAnInvalidJsonPatchShouldThrowAnException() throws IOException {
+    public void applyingNonArrayPatchShouldThrowAnException() throws IOException {
         ObjectMapper objectMapper = new ObjectMapper();
         JsonNode invalid = objectMapper.readTree("{\"not\": \"a patch\"}");
+        JsonNode to = objectMapper.readTree("{\"a\":1}");
+        JsonPatch.apply(invalid, to);
+    }
+
+    @Test(expected = InvalidJsonPatchException.class)
+    public void applyingAnInvalidArrayShouldThrowAnException() throws IOException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode invalid = objectMapper.readTree("[1, 2, 3, 4, 5]");
         JsonNode to = objectMapper.readTree("{\"a\":1}");
         JsonPatch.apply(invalid, to);
     }

--- a/src/test/java/com/flipkart/zjsonpatch/ApiTest.java
+++ b/src/test/java/com/flipkart/zjsonpatch/ApiTest.java
@@ -26,4 +26,33 @@ public class ApiTest {
         JsonNode to = objectMapper.readTree("{\"a\":1}");
         JsonPatch.apply(invalid, to);
     }
+
+    @Test(expected = InvalidJsonPatchException.class)
+    public void applyingAPatchWithAnInvalidOperationShouldThrowAnException() throws IOException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode invalid = objectMapper.readTree("[{\"op\": \"what\"}]");
+        JsonNode to = objectMapper.readTree("{\"a\":1}");
+        JsonPatch.apply(invalid, to);
+    }
+
+    @Test(expected = InvalidJsonPatchException.class)
+    public void validatingNonArrayPatchShouldThrowAnException() throws IOException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode invalid = objectMapper.readTree("{\"not\": \"a patch\"}");
+        JsonPatch.validate(invalid);
+    }
+
+    @Test(expected = InvalidJsonPatchException.class)
+    public void validatingAnInvalidArrayShouldThrowAnException() throws IOException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode invalid = objectMapper.readTree("[1, 2, 3, 4, 5]");
+        JsonPatch.validate(invalid);
+    }
+
+    @Test(expected = InvalidJsonPatchException.class)
+    public void validatingAPatchWithAnInvalidOperationShouldThrowAnException() throws IOException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode invalid = objectMapper.readTree("[{\"op\": \"what\"}]");
+        JsonPatch.validate(invalid);
+    }
 }

--- a/src/test/java/com/flipkart/zjsonpatch/CompatibilityTest.java
+++ b/src/test/java/com/flipkart/zjsonpatch/CompatibilityTest.java
@@ -15,15 +15,17 @@ public class CompatibilityTest {
 
     ObjectMapper mapper;
     JsonNode addNodeWithMissingValue;
+    JsonNode replaceNodeWithMissingValue;
 
     @Before
     public void setUp() throws Exception {
         mapper = new ObjectMapper();
-        addNodeWithMissingValue = mapper.readTree("[{\"op\":\"add\",\"path\":\"test\"}]");
+        addNodeWithMissingValue = mapper.readTree("[{\"op\":\"add\",\"path\":\"a\"}]");
+        replaceNodeWithMissingValue = mapper.readTree("[{\"op\":\"replace\",\"path\":\"a\"}]");
     }
 
     @Test
-    public void withFlagMissingValueShouldBeTreatedAsNulls() throws IOException {
+    public void withFlagAddShouldTreatMissingValuesAsNulls() throws IOException {
         JsonNode expected = mapper.readTree("{\"a\":null}");
         JsonNode result = JsonPatch.apply(addNodeWithMissingValue, mapper.createObjectNode(), MISSING_VALUES_AS_NULLS);
         assertThat(result, equalTo(expected));
@@ -31,6 +33,19 @@ public class CompatibilityTest {
 
     @Test
     public void withFlagAddNodeWithMissingValueShouldValidateCorrectly() {
+        JsonPatch.validate(addNodeWithMissingValue, MISSING_VALUES_AS_NULLS);
+    }
+
+    @Test
+    public void withFlagReplaceShouldTreatMissingValuesAsNull() throws IOException {
+        JsonNode source = mapper.readTree("{\"a\":\"test\"}");
+        JsonNode expected = mapper.readTree("{\"a\":null}");
+        JsonNode result = JsonPatch.apply(replaceNodeWithMissingValue, source, MISSING_VALUES_AS_NULLS);
+        assertThat(result, equalTo(expected));
+    }
+
+    @Test
+    public void withFlagReplaceNodeWithMissingValueShouldValidateCorrectly() {
         JsonPatch.validate(addNodeWithMissingValue, MISSING_VALUES_AS_NULLS);
     }
 }

--- a/src/test/java/com/flipkart/zjsonpatch/CompatibilityTest.java
+++ b/src/test/java/com/flipkart/zjsonpatch/CompatibilityTest.java
@@ -1,0 +1,36 @@
+package com.flipkart.zjsonpatch;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static com.flipkart.zjsonpatch.CompatibilityFlags.*;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class CompatibilityTest {
+
+    ObjectMapper mapper;
+    JsonNode addNodeWithMissingValue;
+
+    @Before
+    public void setUp() throws Exception {
+        mapper = new ObjectMapper();
+        addNodeWithMissingValue = mapper.readTree("[{\"op\":\"add\",\"path\":\"test\"}]");
+    }
+
+    @Test
+    public void withFlagMissingValueShouldBeTreatedAsNulls() throws IOException {
+        JsonNode expected = mapper.readTree("{\"a\":null}");
+        JsonNode result = JsonPatch.apply(addNodeWithMissingValue, mapper.createObjectNode(), MISSING_VALUES_AS_NULLS);
+        assertThat(result, equalTo(expected));
+    }
+
+    @Test
+    public void withFlagAddNodeWithMissingValueShouldValidateCorrectly() {
+        JsonPatch.validate(addNodeWithMissingValue, MISSING_VALUES_AS_NULLS);
+    }
+}

--- a/src/test/java/com/flipkart/zjsonpatch/CompatibilityTest.java
+++ b/src/test/java/com/flipkart/zjsonpatch/CompatibilityTest.java
@@ -6,8 +6,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.EnumSet;
 
-import static com.flipkart.zjsonpatch.CompatibilityFlags.*;
+import static com.flipkart.zjsonpatch.CompatibilityFlags.MISSING_VALUES_AS_NULLS;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
 
@@ -27,25 +28,25 @@ public class CompatibilityTest {
     @Test
     public void withFlagAddShouldTreatMissingValuesAsNulls() throws IOException {
         JsonNode expected = mapper.readTree("{\"a\":null}");
-        JsonNode result = JsonPatch.apply(addNodeWithMissingValue, mapper.createObjectNode(), MISSING_VALUES_AS_NULLS);
+        JsonNode result = JsonPatch.apply(addNodeWithMissingValue, mapper.createObjectNode(), EnumSet.of(MISSING_VALUES_AS_NULLS));
         assertThat(result, equalTo(expected));
     }
 
     @Test
     public void withFlagAddNodeWithMissingValueShouldValidateCorrectly() {
-        JsonPatch.validate(addNodeWithMissingValue, MISSING_VALUES_AS_NULLS);
+        JsonPatch.validate(addNodeWithMissingValue, EnumSet.of(MISSING_VALUES_AS_NULLS));
     }
 
     @Test
     public void withFlagReplaceShouldTreatMissingValuesAsNull() throws IOException {
         JsonNode source = mapper.readTree("{\"a\":\"test\"}");
         JsonNode expected = mapper.readTree("{\"a\":null}");
-        JsonNode result = JsonPatch.apply(replaceNodeWithMissingValue, source, MISSING_VALUES_AS_NULLS);
+        JsonNode result = JsonPatch.apply(replaceNodeWithMissingValue, source, EnumSet.of(MISSING_VALUES_AS_NULLS));
         assertThat(result, equalTo(expected));
     }
 
     @Test
     public void withFlagReplaceNodeWithMissingValueShouldValidateCorrectly() {
-        JsonPatch.validate(addNodeWithMissingValue, MISSING_VALUES_AS_NULLS);
+        JsonPatch.validate(addNodeWithMissingValue, EnumSet.of(MISSING_VALUES_AS_NULLS));
     }
 }

--- a/src/test/resources/testdata/add.json
+++ b/src/test/resources/testdata/add.json
@@ -1,6 +1,10 @@
 {
     "errors": [
-
+        {
+            "op": [{ "op": "add", "path": "/a" }],
+            "node": {},
+            "message": "Missing value field on add operation"
+        }
     ],
     "ops": [
         {

--- a/src/test/resources/testdata/move.json
+++ b/src/test/resources/testdata/move.json
@@ -9,6 +9,11 @@
             "op": [{ "op": "move", "from": "/a", "path": "/b/c" }],
             "node": { "a": "b" },
             "message": "jsonPatch.noSuchParent"
+        },
+        {
+            "op": [{ "op": "move", "path": "/b/c" }],
+            "node": { "a": "b" },
+            "message": "Missing from field"
         }
     ],
     "ops": [

--- a/src/test/resources/testdata/replace.json
+++ b/src/test/resources/testdata/replace.json
@@ -1,6 +1,11 @@
 {
     "errors": [
         {
+            "op": [{ "op": "replace", "path": "/a" }],
+            "node": { "a": 0 },
+            "message": "Missing value field"
+        },
+        {
             "op": [{ "op": "replace", "path": "/x/y", "value": false }],
             "node": { "x": "a" }
         }


### PR DESCRIPTION
Fundamentally this is about adding a `JsonPatch.validate` API to the library. To that end, this pull requests includes the following changes:

* Separated `JsonPatch` into two separate concerns:
  * `JsonPatch` provides the top-level APIs (`apply` and `validate`) and handles RFC 6902 "schema" (i.e. the shape of the JSON patch node)
  * A `JsonPatchProcessor` interface (package-internal) handles the actual application of the patch
* An `ApplyProcessor` now contains all of the actual actual patch application logic previously mixed into `JsonPatch`
* To support this, `ApplyProcessor` is stateful and directly mutates a `JsonNode` (this is actually the same behavior as before, but is now encoded in the API)
* A second `NoopProcessor` (self-documenting) is provided for validation purposes
* A new `JsonPatch.validate(JsonNode patch)` static method is provided

This will later allow custom processing variants (e.g. allowing value-less `ADD` operations to maintain backwards compatibility with versions <=0.2.1). This isn't actually a very big change, but I'll be more than happy to discuss the rationale and approach.