### PR TITLE
Fork to use Java 8 instead of Guava library.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target/*
 *.iws
 *.idea
 flipkart-boot.log
+/target/

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,10 @@
             <name>Gopi Vishwakarma</name>
             <email>vishwakarma.iiita@gmail.com</email>
         </developer>
+        <developer>
+            <id>vkovalchuk</id>
+            <email>vladimir.v.kovalchuk@gmail.com</email>
+        </developer>
     </developers>
 
     <licenses>
@@ -45,8 +49,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.3.1</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                     <showDeprecation>true</showDeprecation>
                     <showWarnings>true</showWarnings>
                 </configuration>
@@ -126,11 +130,7 @@
             <artifactId>jackson-core</artifactId>
             <version>2.3.2</version>
         </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>18.0</version>
-        </dependency>
+
         <dependency>
             <scope>test</scope>
             <groupId>commons-io</groupId>

--- a/src/main/java/com/flipkart/zjsonpatch/Constants.java
+++ b/src/main/java/com/flipkart/zjsonpatch/Constants.java
@@ -6,12 +6,9 @@ package com.flipkart.zjsonpatch;
  * Date: 10/07/15
  * Time: 10:35 AM
  */
-final class Constants {
-    public static String OP = "op";
-    public static String VALUE = "value";
-    public static String PATH = "path";
-    public static String FROM = "from";
-
-    private Constants() {}
-
+interface Constants {
+    String OP = "op";
+    String VALUE = "value";
+    String PATH = "path";
+    String FROM = "from";
 }

--- a/src/main/java/com/flipkart/zjsonpatch/NodeType.java
+++ b/src/main/java/com/flipkart/zjsonpatch/NodeType.java
@@ -2,10 +2,10 @@ package com.flipkart.zjsonpatch;
 
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.base.Preconditions;
 
 import java.util.EnumMap;
 import java.util.Map;
+import java.util.Objects;
 
 enum NodeType {
     /**
@@ -69,7 +69,7 @@ enum NodeType {
     public static NodeType getNodeType(final JsonNode node) {
         final JsonToken token = node.asToken();
         final NodeType ret = TOKEN_MAP.get(token);
-        Preconditions.checkNotNull(ret, "unhandled token type " + token);
+        Objects.requireNonNull(ret, () -> "unhandled token type " + token);
         return ret;
     }
 }

--- a/src/main/java/com/flipkart/zjsonpatch/Operation.java
+++ b/src/main/java/com/flipkart/zjsonpatch/Operation.java
@@ -1,10 +1,6 @@
 package com.flipkart.zjsonpatch;
 
-import com.google.common.collect.ImmutableMap;
-
-import java.util.Map;
-
-import static com.google.common.base.Preconditions.checkNotNull;
+import java.util.*;
 
 /**
  * User: gopi.vishwakarma
@@ -16,12 +12,14 @@ enum Operation {
     REPLACE("replace"),
     MOVE("move");
 
-    private final static Map<String, Operation> OPS = ImmutableMap.of(
-            ADD.rfcName, ADD,
-            REMOVE.rfcName, REMOVE,
-            REPLACE.rfcName, REPLACE,
-            MOVE.rfcName, MOVE
-            );
+    private static final Map<String, Operation> opMap = new HashMap<>();
+    static {
+        opMap.put(ADD.rfcName, ADD);
+        opMap.put(REMOVE.rfcName, REMOVE);
+        opMap.put(REPLACE.rfcName, REPLACE);
+        opMap.put(MOVE.rfcName, MOVE);
+    }
+    private final static Map<String, Operation> OPS = Collections.unmodifiableMap(opMap);
 
     private String rfcName;
 
@@ -30,8 +28,10 @@ enum Operation {
     }
 
     public static Operation fromRfcName(String rfcName) {
-        checkNotNull(rfcName, "rfcName cannot be null");
-        return checkNotNull(OPS.get(rfcName.toLowerCase()), "unknown / unsupported operation %s", rfcName);
+        Objects.requireNonNull(rfcName, "rfcName cannot be null");
+        Operation op = OPS.get(rfcName.toLowerCase());
+        return Objects.requireNonNull(op,
+                () -> ("unknown / unsupported operation " + rfcName));
     }
 
     public String rfcName() {


### PR DESCRIPTION
Guava dependency is effectively disabled in my setup due to classpath conflict and no, I cannot change classpath (externally-managed Cloudera CDH 5.7) One way to resolve this is using Java 8 instead. Java 6 is dead, 7 is almost dead (no security patches to general public soon). Here's the patch. All the unit tests are passing.
