### PR TITLE
Upgrade commons-collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Add following to `<dependencies/>` section of your pom.xml -
 <artifactId>zjsonpatch</artifactId>
 <version>{version}</version>
 ```
-- Avaibale on maven cental repository 
+- Available on maven cental repository
 - Available on Clojars repository, access by adding following to your `<repositories/>` section of pom.xml -
 ```xml
 <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-collections4</artifactId>
-            <version>4.0</version>
+            <version>4.1</version>
         </dependency>
     </dependencies>
     <distributionManagement>


### PR DESCRIPTION
Hello :)

When checking some projects with Dependency-check I discovered that zjsonpatch depends on a vulnerable version of commons-collections4:

```
One or more dependencies were identified with known vulnerabilities in zjsonpatch:

commons-collections4-4.0.jar (cpe:/a:apache:commons_collections:4.0, org.apache.commons:commons-collections4:4.0) : CVE-2015-6420
```

See http://commons.apache.org/proper/commons-collections/release_4_1.html or https://issues.apache.org/jira/browse/COLLECTIONS-580 for more details.

`mvn clean install` ran succesfully after upgrading (though with the gpg-signing part commented out). Btw, it looks like a couple of the other dependencies can be upgraded as well.

Oh, and I fixed a small typo I spotted in the README.