### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ### Compatible with : Java 6 / 7 / 8
 
-##Code Coverage
+## Code Coverage
 Package      |	Class, % 	 |  Method, % 	   |  Line, %           |
 -------------|---------------|-----------------|--------------------|
 all classes  |	100% (6/ 6)  |	93.6% (44/ 47) |  96.2% (332/ 345)  |


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
