### PR TITLE
Added a compatibility flag which allows the removal of none existing …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.flipkart.zjsonpatch</groupId>
     <artifactId>zjsonpatch</artifactId>
-    <version>0.3.6-SNAPSHOT</version>
+    <version>0.3.7-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>zjsonpatch</name>
@@ -78,42 +78,42 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.3</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.4</version>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <version>2.5</version>
-                <configuration>
-                    <autoVersionSubmodules>true</autoVersionSubmodules>
-                    <useReleaseProfile>false</useReleaseProfile>
-                    <releaseProfiles>release</releaseProfiles>
-                    <goals>deploy</goals>
-                </configuration>
-            </plugin>
+            <!--<plugin>-->
+                <!--<groupId>org.sonatype.plugins</groupId>-->
+                <!--<artifactId>nexus-staging-maven-plugin</artifactId>-->
+                <!--<version>1.6.3</version>-->
+                <!--<extensions>true</extensions>-->
+                <!--<configuration>-->
+                    <!--<serverId>ossrh</serverId>-->
+                    <!--<nexusUrl>https://oss.sonatype.org/</nexusUrl>-->
+                    <!--<autoReleaseAfterClose>true</autoReleaseAfterClose>-->
+                <!--</configuration>-->
+            <!--</plugin>-->
+            <!--<plugin>-->
+                <!--<groupId>org.apache.maven.plugins</groupId>-->
+                <!--<artifactId>maven-gpg-plugin</artifactId>-->
+                <!--<version>1.4</version>-->
+                <!--<executions>-->
+                    <!--<execution>-->
+                        <!--<id>sign-artifacts</id>-->
+                        <!--<phase>verify</phase>-->
+                        <!--<goals>-->
+                            <!--<goal>sign</goal>-->
+                        <!--</goals>-->
+                    <!--</execution>-->
+                <!--</executions>-->
+            <!--</plugin>-->
+            <!--<plugin>-->
+                <!--<groupId>org.apache.maven.plugins</groupId>-->
+                <!--<artifactId>maven-release-plugin</artifactId>-->
+                <!--<version>2.5</version>-->
+                <!--<configuration>-->
+                    <!--<autoVersionSubmodules>true</autoVersionSubmodules>-->
+                    <!--<useReleaseProfile>false</useReleaseProfile>-->
+                    <!--<releaseProfiles>release</releaseProfiles>-->
+                    <!--<goals>deploy</goals>-->
+                <!--</configuration>-->
+            <!--</plugin>-->
         </plugins>
     </build>
     <dependencies>

--- a/src/main/java/com/flipkart/zjsonpatch/CompatibilityFlags.java
+++ b/src/main/java/com/flipkart/zjsonpatch/CompatibilityFlags.java
@@ -22,7 +22,7 @@ import java.util.EnumSet;
  * Created by tomerga on 04/09/2016.
  */
 public enum CompatibilityFlags {
-    MISSING_VALUES_AS_NULLS;
+    MISSING_VALUES_AS_NULLS, REMOVE_NONE_EXISTING_ARRAY_ELEMENT;
 
     public static EnumSet<CompatibilityFlags> defaults() {
         return EnumSet.noneOf(CompatibilityFlags.class);

--- a/src/main/java/com/flipkart/zjsonpatch/CopyingApplyProcessor.java
+++ b/src/main/java/com/flipkart/zjsonpatch/CopyingApplyProcessor.java
@@ -1,10 +1,15 @@
 package com.flipkart.zjsonpatch;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import java.util.EnumSet;
 
 class CopyingApplyProcessor extends InPlaceApplyProcessor {
 
     CopyingApplyProcessor(JsonNode target) {
-        super(target.deepCopy());
+        this(target, CompatibilityFlags.defaults());
+    }
+
+    CopyingApplyProcessor(JsonNode target, EnumSet<CompatibilityFlags> flags) {
+        super(target.deepCopy(), flags);
     }
 }

--- a/src/main/java/com/flipkart/zjsonpatch/JsonPatch.java
+++ b/src/main/java/com/flipkart/zjsonpatch/JsonPatch.java
@@ -131,7 +131,7 @@ public final class JsonPatch {
     }
 
     public static JsonNode apply(JsonNode patch, JsonNode source, EnumSet<CompatibilityFlags> flags) throws JsonPatchApplicationException {
-        CopyingApplyProcessor processor = new CopyingApplyProcessor(source);
+        CopyingApplyProcessor processor = new CopyingApplyProcessor(source, flags);
         process(patch, processor, flags);
         return processor.result();
     }
@@ -145,7 +145,7 @@ public final class JsonPatch {
     }
 
     public static void applyInPlace(JsonNode patch, JsonNode source, EnumSet<CompatibilityFlags> flags){
-        InPlaceApplyProcessor processor = new InPlaceApplyProcessor(source);
+        InPlaceApplyProcessor processor = new InPlaceApplyProcessor(source, flags);
         process(patch, processor, flags);
     }
 

--- a/src/test/java/com/flipkart/zjsonpatch/CompatibilityTest.java
+++ b/src/test/java/com/flipkart/zjsonpatch/CompatibilityTest.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.util.EnumSet;
 
 import static com.flipkart.zjsonpatch.CompatibilityFlags.MISSING_VALUES_AS_NULLS;
+import static com.flipkart.zjsonpatch.CompatibilityFlags.REMOVE_NONE_EXISTING_ARRAY_ELEMENT;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
 
@@ -33,12 +34,14 @@ public class CompatibilityTest {
     ObjectMapper mapper;
     JsonNode addNodeWithMissingValue;
     JsonNode replaceNodeWithMissingValue;
+    JsonNode removeNoneExistingArrayElement;
 
     @Before
     public void setUp() throws Exception {
         mapper = new ObjectMapper();
         addNodeWithMissingValue = mapper.readTree("[{\"op\":\"add\",\"path\":\"a\"}]");
         replaceNodeWithMissingValue = mapper.readTree("[{\"op\":\"replace\",\"path\":\"a\"}]");
+        removeNoneExistingArrayElement = mapper.readTree("[{\"op\": \"remove\",\"path\": \"/b/0\"}]");
     }
 
     @Test
@@ -64,5 +67,13 @@ public class CompatibilityTest {
     @Test
     public void withFlagReplaceNodeWithMissingValueShouldValidateCorrectly() {
         JsonPatch.validate(addNodeWithMissingValue, EnumSet.of(MISSING_VALUES_AS_NULLS));
+    }
+
+    @Test
+    public void withFlagIgnoreRemoveNoneExistingArrayElement() throws IOException {
+        JsonNode source = mapper.readTree("{\"b\": []}");
+        JsonNode expected = mapper.readTree("{\"b\": []}");
+        JsonNode result = JsonPatch.apply(removeNoneExistingArrayElement, source, EnumSet.of(REMOVE_NONE_EXISTING_ARRAY_ELEMENT));
+        assertThat(result, equalTo(expected));
     }
 }


### PR DESCRIPTION
…array elements
Hi, I work in Wix (some of my colleagues have already contributed to this project).
We have old jsonpatch diffs in our db, which were validated with version 0.2.1. They contain erroneous payloads created by an external client. We want to upgrade to version 0.3.x, which (correctly) considers these payloads invalid.
We have added a backward-compatibility flag which allows the removal of none-existing array elements.

Thanks!
Eran