### PR TITLE
Tiny optimisations

### DIFF
--- a/src/main/java/com/flipkart/zjsonpatch/DiffFlags.java
+++ b/src/main/java/com/flipkart/zjsonpatch/DiffFlags.java
@@ -1,6 +1,5 @@
 package com.flipkart.zjsonpatch;
 
-import java.util.Arrays;
 import java.util.EnumSet;
 
 public enum DiffFlags {
@@ -13,6 +12,6 @@ public enum DiffFlags {
     }
 
     public static EnumSet<DiffFlags> dontNormalizeOpIntoMoveAndCopy() {
-        return EnumSet.copyOf(Arrays.asList(OMIT_MOVE_OPERATION, OMIT_COPY_OPERATION));
+        return EnumSet.of(OMIT_MOVE_OPERATION, OMIT_COPY_OPERATION);
     }
 }

--- a/src/main/java/com/flipkart/zjsonpatch/EncodePathFunction.java
+++ b/src/main/java/com/flipkart/zjsonpatch/EncodePathFunction.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016 flipkart.com zjsonpatch.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package com.flipkart.zjsonpatch;
+
+import java.util.regex.Pattern;
+
+import com.google.common.base.Function;
+
+final class EncodePathFunction implements Function<Object, String> {
+    private static final EncodePathFunction INSTANCE = new EncodePathFunction();
+    private static final Pattern TILDA_PATTERN = Pattern.compile("~");
+    private static final Pattern SLASH_PATTERN = Pattern.compile("/");
+
+    private EncodePathFunction() {
+    }
+
+    static EncodePathFunction getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public String apply(Object object) {
+        String path = object.toString(); // see http://tools.ietf.org/html/rfc6901#section-4
+        path = TILDA_PATTERN.matcher(path).replaceAll("~0");
+        return SLASH_PATTERN.matcher(path).replaceAll("~1");
+    }
+}

--- a/src/main/java/com/flipkart/zjsonpatch/InPlaceApplyProcessor.java
+++ b/src/main/java/com/flipkart/zjsonpatch/InPlaceApplyProcessor.java
@@ -19,7 +19,6 @@ package com.flipkart.zjsonpatch;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.common.collect.Iterables;
@@ -36,16 +35,6 @@ class InPlaceApplyProcessor implements JsonPatchProcessor {
 
     public JsonNode result() {
         return target;
-    }
-
-    private static final EncodePathFunction ENCODE_PATH_FUNCTION = new EncodePathFunction();
-
-    private final static class EncodePathFunction implements Function<Object, String> {
-        @Override
-        public String apply(Object object) {
-            String path = object.toString(); // see http://tools.ietf.org/html/rfc6901#section-4
-            return path.replaceAll("~", "~0").replaceAll("/", "~1");
-        }
     }
 
     @Override
@@ -228,6 +217,6 @@ class InPlaceApplyProcessor implements JsonPatchProcessor {
     }
     private static String getArrayNodeRepresentation(List<String> path) {
         return Joiner.on('/').appendTo(new StringBuilder().append('/'),
-                Iterables.transform(path, ENCODE_PATH_FUNCTION)).toString();
+                Iterables.transform(path, EncodePathFunction.getInstance())).toString();
     }
 }

--- a/src/main/java/com/flipkart/zjsonpatch/JsonDiff.java
+++ b/src/main/java/com/flipkart/zjsonpatch/JsonDiff.java
@@ -85,7 +85,7 @@ public final class JsonDiff {
         Map<JsonNode, List<Object>> unchangedValues = getUnchangedPart(source, target);
         for (int i = 0; i < diffs.size(); i++) {
             Diff diff = diffs.get(i);
-            if (Operation.ADD.equals(diff.getOperation())) {
+            if (Operation.ADD == diff.getOperation()) {
                 List<Object> matchingValuePath = getMatchingValuePath(unchangedValues, diff.getValue());
                 if (matchingValuePath != null && isAllowed(matchingValuePath, diff.getPath())) {
                     diffs.set(i, new Diff(Operation.COPY, matchingValuePath, diff.getPath()));
@@ -188,8 +188,8 @@ public final class JsonDiff {
             Diff diff1 = diffs.get(i);
 
             // if not remove OR add, move to next diff
-            if (!(Operation.REMOVE.equals(diff1.getOperation()) ||
-                    Operation.ADD.equals(diff1.getOperation()))) {
+            if (!(Operation.REMOVE == diff1.getOperation() ||
+                    Operation.ADD == diff1.getOperation())) {
                 continue;
             }
 
@@ -200,13 +200,13 @@ public final class JsonDiff {
                 }
 
                 Diff moveDiff = null;
-                if (Operation.REMOVE.equals(diff1.getOperation()) &&
-                        Operation.ADD.equals(diff2.getOperation())) {
+                if (Operation.REMOVE == diff1.getOperation() &&
+                        Operation.ADD == diff2.getOperation()) {
                     computeRelativePath(diff2.getPath(), i + 1, j - 1, diffs);
                     moveDiff = new Diff(Operation.MOVE, diff1.getPath(), diff2.getPath());
 
-                } else if (Operation.ADD.equals(diff1.getOperation()) &&
-                        Operation.REMOVE.equals(diff2.getOperation())) {
+                } else if (Operation.ADD == diff1.getOperation() &&
+                        Operation.REMOVE == diff2.getOperation()) {
                     computeRelativePath(diff2.getPath(), i, j - 1, diffs); // diff1's add should also be considered
                     moveDiff = new Diff(Operation.MOVE, diff2.getPath(), diff1.getPath());
                 }
@@ -229,7 +229,7 @@ public final class JsonDiff {
         for (int i = startIdx; i <= endIdx; i++) {
             Diff diff = diffs.get(i);
             //Adjust relative path according to #ADD and #Remove
-            if (Operation.ADD.equals(diff.getOperation()) || Operation.REMOVE.equals(diff.getOperation())) {
+            if (Operation.ADD == diff.getOperation() || Operation.REMOVE == diff.getOperation()) {
                 updatePath(path, diff, counters);
             }
         }
@@ -273,10 +273,10 @@ public final class JsonDiff {
     }
 
     private static void updateCounters(Diff pseudo, int idx, List<Integer> counters) {
-        if (Operation.ADD.equals(pseudo.getOperation())) {
+        if (Operation.ADD == pseudo.getOperation()) {
             counters.set(idx, counters.get(idx) - 1);
         } else {
-            if (Operation.REMOVE.equals(pseudo.getOperation())) {
+            if (Operation.REMOVE == pseudo.getOperation()) {
                 counters.set(idx, counters.get(idx) + 1);
             }
         }

--- a/src/main/java/com/flipkart/zjsonpatch/JsonDiff.java
+++ b/src/main/java/com/flipkart/zjsonpatch/JsonDiff.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
@@ -35,17 +34,7 @@ import java.util.*;
  */
 public final class JsonDiff {
 
-    private static final EncodePathFunction ENCODE_PATH_FUNCTION = new EncodePathFunction();
-
     private JsonDiff() {
-    }
-
-    private final static class EncodePathFunction implements Function<Object, String> {
-        @Override
-        public String apply(Object object) {
-            String path = object.toString(); // see http://tools.ietf.org/html/rfc6901#section-4
-            return path.replaceAll("~", "~0").replaceAll("/", "~1");
-        }
     }
 
     public static JsonNode asJson(final JsonNode source, final JsonNode target) {
@@ -326,7 +315,7 @@ public final class JsonDiff {
 
     private static String getArrayNodeRepresentation(List<Object> path) {
         return Joiner.on('/').appendTo(new StringBuilder().append('/'),
-                Iterables.transform(path, ENCODE_PATH_FUNCTION)).toString();
+                Iterables.transform(path, EncodePathFunction.getInstance())).toString();
     }
 
 

--- a/src/main/java/com/flipkart/zjsonpatch/JsonDiff.java
+++ b/src/main/java/com/flipkart/zjsonpatch/JsonDiff.java
@@ -142,6 +142,7 @@ public final class JsonDiff {
                     break;
                 case ARRAY:
                     computeArray(unchangedValues, path, source, target);
+                    break;
                 default:
                 /* nothing */
             }

--- a/src/main/java/com/flipkart/zjsonpatch/JsonDiff.java
+++ b/src/main/java/com/flipkart/zjsonpatch/JsonDiff.java
@@ -43,7 +43,7 @@ public final class JsonDiff {
 
     public static JsonNode asJson(final JsonNode source, final JsonNode target, EnumSet<DiffFlags> flags) {
         final List<Diff> diffs = new ArrayList<Diff>();
-        List<Object> path = new LinkedList<Object>();
+        List<Object> path = new ArrayList<Object>(0);
         /*
          * generating diffs in the order of their occurrence
          */

--- a/src/main/java/com/flipkart/zjsonpatch/JsonDiff.java
+++ b/src/main/java/com/flipkart/zjsonpatch/JsonDiff.java
@@ -212,7 +212,7 @@ public final class JsonDiff {
     //Note : only to be used for arrays
     //Finds the longest common Ancestor ending at Array
     private static void computeRelativePath(List<Object> path, int startIdx, int endIdx, List<Diff> diffs) {
-        List<Integer> counters = new ArrayList<Integer>();
+        List<Integer> counters = new ArrayList<Integer>(path.size());
 
         resetCounters(counters, path.size());
 
@@ -442,7 +442,7 @@ public final class JsonDiff {
     }
 
     private static List<Object> getPath(List<Object> path, Object key) {
-        List<Object> toReturn = new ArrayList<Object>();
+        List<Object> toReturn = new ArrayList<Object>(path.size() + 1);
         toReturn.addAll(path);
         toReturn.add(key);
         return toReturn;


### PR DESCRIPTION
I've made a series of commits, each containing a small and simple optimization:
- Compare enums with `==` instead of `equals()` to avoid method calls
- Precompile regexps into `Pattern`s (and remove duplicate classes)
- Don't fall through a `case` into the `default` `case` (even if it's currently empty)
- Create `ArrayList` with the correct size when known to reduce garbage
- Use `ArrayList` consistently
- Simplify the creation of an `EnumSet` with 2 elements