### PR TITLE
Compatibility Fixes

### DIFF
--- a/src/main/java/com/flipkart/zjsonpatch/CompatibilityFlags.java
+++ b/src/main/java/com/flipkart/zjsonpatch/CompatibilityFlags.java
@@ -22,7 +22,8 @@ import java.util.EnumSet;
  * Created by tomerga on 04/09/2016.
  */
 public enum CompatibilityFlags {
-    MISSING_VALUES_AS_NULLS, REMOVE_NONE_EXISTING_ARRAY_ELEMENT;
+    MISSING_VALUES_AS_NULLS,
+    REMOVE_NONE_EXISTING_ARRAY_ELEMENT;
 
     public static EnumSet<CompatibilityFlags> defaults() {
         return EnumSet.noneOf(CompatibilityFlags.class);

--- a/src/main/java/com/flipkart/zjsonpatch/DiffFlags.java
+++ b/src/main/java/com/flipkart/zjsonpatch/DiffFlags.java
@@ -4,13 +4,39 @@ import java.util.EnumSet;
 
 public enum DiffFlags {
     /**
-     *
+     * This flag omits the <i>value</i> field on remove operations.
+     * This is a default flag.
      */
     OMIT_VALUE_ON_REMOVE,
-    OMIT_MOVE_OPERATION, //only have ADD, REMOVE, REPLACE, COPY Don't normalize operations into MOVE
-    OMIT_COPY_OPERATION, //only have ADD, REMOVE, REPLACE, MOVE, Don't normalize operations into COPY
+
+    /**
+     * This flag omits all {@link Operation#MOVE} operations, leaving only
+     * {@link Operation#ADD}, {@link Operation#REMOVE}, {@link Operation#REPLACE}
+     * and {@link Operation#COPY} operations. In other words, without this flag,
+     * {@link Operation#ADD} and {@link Operation#REMOVE} operations are not normalized
+     * into {@link Operation#MOVE} operations.
+     */
+    OMIT_MOVE_OPERATION,
+
+    /**
+     * This flag omits all {@link Operation#COPY} operations, leaving only
+     * {@link Operation#ADD}, {@link Operation#REMOVE}, {@link Operation#REPLACE}
+     * and {@link Operation#MOVE} operations. In other words, without this flag,
+     * {@link Operation#ADD} operations are not normalized into {@link Operation#COPY}
+     * operations.
+     */
+    OMIT_COPY_OPERATION,
+
+    /**
+     * This flag adds a <i>fromValue</i> field to all {@link Operation#REPLACE}operations.
+     * <i>fromValue</i> represents the the value replaced by a {@link Operation#REPLACE}
+     * operation, in other words, the original value.
+     *
+     * @since 0.4.1
+     */
     ADD_ORIGINAL_VALUE_ON_REPLACE;
-    
+
+
     public static EnumSet<DiffFlags> defaults() {
         return EnumSet.of(OMIT_VALUE_ON_REMOVE);
     }

--- a/src/main/java/com/flipkart/zjsonpatch/DiffFlags.java
+++ b/src/main/java/com/flipkart/zjsonpatch/DiffFlags.java
@@ -3,13 +3,16 @@ package com.flipkart.zjsonpatch;
 import java.util.EnumSet;
 
 public enum DiffFlags {
+    /**
+     *
+     */
     OMIT_VALUE_ON_REMOVE,
     OMIT_MOVE_OPERATION, //only have ADD, REMOVE, REPLACE, COPY Don't normalize operations into MOVE
     OMIT_COPY_OPERATION, //only have ADD, REMOVE, REPLACE, MOVE, Don't normalize operations into COPY
-    OMIT_ORIGINAL_VALUE_ON_REPLACE;
+    ADD_ORIGINAL_VALUE_ON_REPLACE;
     
     public static EnumSet<DiffFlags> defaults() {
-        return EnumSet.of(OMIT_VALUE_ON_REMOVE, OMIT_ORIGINAL_VALUE_ON_REPLACE);
+        return EnumSet.of(OMIT_VALUE_ON_REMOVE);
     }
 
     public static EnumSet<DiffFlags> dontNormalizeOpIntoMoveAndCopy() {

--- a/src/main/java/com/flipkart/zjsonpatch/JsonDiff.java
+++ b/src/main/java/com/flipkart/zjsonpatch/JsonDiff.java
@@ -27,9 +27,11 @@ import java.util.*;
  * User: gopi.vishwakarma
  * Date: 30/07/14
  */
+
 public final class JsonDiff {
 
     private JsonDiff() {
+
     }
 
     public static JsonNode asJson(final JsonNode source, final JsonNode target) {
@@ -295,7 +297,7 @@ public final class JsonDiff {
                 break;
 
             case REPLACE:
-                if (!flags.contains(DiffFlags.OMIT_ORIGINAL_VALUE_ON_REPLACE)) {
+                if (flags.contains(DiffFlags.ADD_ORIGINAL_VALUE_ON_REPLACE)) {
                     jsonNode.set(Constants.FROM_VALUE, diff.getSrcValue());
                 }
             case ADD:

--- a/src/main/java/com/flipkart/zjsonpatch/NoopProcessor.java
+++ b/src/main/java/com/flipkart/zjsonpatch/NoopProcessor.java
@@ -20,9 +20,11 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 import java.util.List;
 
-/** A JSON patch processor that does nothing, intended for testing and validation. */
+/**
+ * A JSON patch processor that does nothing, intended for testing and validation.
+ */
 public class NoopProcessor implements JsonPatchProcessor {
-    static NoopProcessor INSTANCE;
+    static final NoopProcessor INSTANCE;
     static {
         INSTANCE = new NoopProcessor();
     }

--- a/src/test/java/com/flipkart/zjsonpatch/AbstractTest.java
+++ b/src/test/java/com/flipkart/zjsonpatch/AbstractTest.java
@@ -31,6 +31,7 @@ import java.io.StringWriter;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.hamcrest.core.StringContains.containsString;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
@@ -56,14 +57,16 @@ public abstract class AbstractTest {
     private void testOperation() throws Exception {
         JsonNode node = p.getNode();
 
-        JsonNode first = node.get("node");
-        JsonNode second = node.get("expected");
+        JsonNode doc = node.get("node");
+        JsonNode expected = node.get("expected");
         JsonNode patch = node.get("op");
         String message = node.has("message") ? node.get("message").toString() : "";
 
-        JsonNode secondPrime = JsonPatch.apply(patch, first);
-
-        assertThat(message, secondPrime, equalTo(second));
+        JsonNode result = JsonPatch.apply(patch, doc);
+        String failMessage = "The following test failed: \n" +
+                "message: " + message + '\n' +
+                "at: " + p.getSourceFile();
+        assertEquals(failMessage, expected, result);
     }
 
     private Class<?> exceptionType(String type) throws ClassNotFoundException {


### PR DESCRIPTION
In this PR, I propose to revert back the compatibility break cited in https://github.com/flipkart-incubator/zjsonpatch/issues/61, replacing the OMIT_ORIGINAL_VALUE_ON_REPLACE with ADD_ORIGINAL_VALUE_ON_REPLACE.

I think it's best to change the flag and break some recent compatibility instead of breaking all pre-0.3.5 compatibility.