### PR TITLE
Drop support for Java <8, enable compilation under JDK 15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <compileSource>1.6</compileSource>
+        <compileSource>1.8</compileSource>
         <testCompileSource>1.8</testCompileSource>
 
         <jackson.version>2.10.3</jackson.version>
@@ -85,7 +85,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9.1</version>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>


### PR DESCRIPTION
1.6 source level is no longer supported, and 1.7 is deprecated and will be removed soonish. Time to level up.