### PR TITLE
Add value to move and copy operations

### DIFF
--- a/src/main/java/com/flipkart/zjsonpatch/Diff.java
+++ b/src/main/java/com/flipkart/zjsonpatch/Diff.java
@@ -43,6 +43,14 @@ class Diff {
         this.value = null;
         this.srcValue = null;
     }
+
+    Diff(Operation operation, JsonPointer fromPath, JsonPointer toPath, JsonNode value) {
+        this.operation = operation;
+        this.path = fromPath;
+        this.toPath = toPath;
+        this.value = value;
+        this.srcValue = null;
+    }
     
     Diff(Operation operation, JsonPointer path, JsonNode srcValue, JsonNode value) {
         this.operation = operation;

--- a/src/main/java/com/flipkart/zjsonpatch/JsonDiff.java
+++ b/src/main/java/com/flipkart/zjsonpatch/JsonDiff.java
@@ -93,7 +93,7 @@ public final class JsonDiff {
                     diffs.add(i, new Diff(Operation.TEST, matchingValuePath, diff.getValue()));
                     i++;
                 }
-                diffs.set(i, new Diff(Operation.COPY, matchingValuePath, diff.getPath()));
+                diffs.set(i, new Diff(Operation.COPY, matchingValuePath, diff.getPath(), diff.getValue()));
             }
         }
     }
@@ -209,12 +209,12 @@ public final class JsonDiff {
                 if (Operation.REMOVE == diff1.getOperation() &&
                         Operation.ADD == diff2.getOperation()) {
                     JsonPointer relativePath = computeRelativePath(diff2.getPath(), i + 1, j - 1, diffs);
-                    moveDiff = new Diff(Operation.MOVE, diff1.getPath(), relativePath);
+                    moveDiff = new Diff(Operation.MOVE, diff1.getPath(), relativePath, diff2.getValue());
 
                 } else if (Operation.ADD == diff1.getOperation() &&
                         Operation.REMOVE == diff2.getOperation()) {
                     JsonPointer relativePath = computeRelativePath(diff2.getPath(), i, j - 1, diffs); // diff1's add should also be considered
-                    moveDiff = new Diff(Operation.MOVE, relativePath, diff1.getPath());
+                    moveDiff = new Diff(Operation.MOVE, relativePath, diff1.getPath(), diff1.getValue());
                 }
                 if (moveDiff != null) {
                     diffs.remove(j);
@@ -322,6 +322,7 @@ public final class JsonDiff {
         switch (diff.getOperation()) {
             case MOVE:
             case COPY:
+                jsonNode.set(Constants.VALUE, diff.getValue());
                 jsonNode.put(Constants.FROM, diff.getPath().toString());    // required {from} only in case of Move Operation
                 jsonNode.put(Constants.PATH, diff.getToPath().toString());  // destination Path
                 break;

--- a/src/test/java/com/flipkart/zjsonpatch/MoveOperationTest.java
+++ b/src/test/java/com/flipkart/zjsonpatch/MoveOperationTest.java
@@ -43,7 +43,9 @@ public class MoveOperationTest extends AbstractTest {
     public void testMoveValueGeneratedHasNoValue() throws IOException {
         JsonNode jsonNode1 = MAPPER.readTree("{ \"foo\": { \"bar\": \"baz\", \"waldo\": \"fred\" }, \"qux\": { \"corge\": \"grault\" } }");
         JsonNode jsonNode2 = MAPPER.readTree("{ \"foo\": { \"bar\": \"baz\" }, \"qux\": { \"corge\": \"grault\", \"thud\": \"fred\" } }");
-        JsonNode patch = MAPPER.readTree("[{\"op\":\"move\",\"from\":\"/foo/waldo\",\"path\":\"/qux/thud\"}]");
+        JsonNode patch = MAPPER.readTree(
+                "[{\"op\":\"move\",\"value\":\"fred\",\"from\":\"/foo/waldo\",\"path\":\"/qux/thud\"}]"
+        );
 
         JsonNode diff = JsonDiff.asJson(jsonNode1, jsonNode2);
 
@@ -54,7 +56,9 @@ public class MoveOperationTest extends AbstractTest {
     public void testMoveArrayGeneratedHasNoValue() throws IOException {
         JsonNode jsonNode1 = MAPPER.readTree("{ \"foo\": [ \"all\", \"grass\", \"cows\", \"eat\" ] }");
         JsonNode jsonNode2 = MAPPER.readTree("{ \"foo\": [ \"all\", \"cows\", \"eat\", \"grass\" ] }");
-        JsonNode patch = MAPPER.readTree("[{\"op\":\"move\",\"from\":\"/foo/1\",\"path\":\"/foo/3\"}]");
+        JsonNode patch = MAPPER.readTree(
+                "[{\"op\":\"move\",\"value\":\"grass\",\"from\":\"/foo/1\",\"path\":\"/foo/3\"}]"
+        );
 
         JsonNode diff = JsonDiff.asJson(jsonNode1, jsonNode2);
 


### PR DESCRIPTION
At the moment it is not possible to get which value was moved or copied when computing a diff because the paths need to be computed step by step.

This pull-request adds the value to those operations when they are computed, which allows to get the value directly from a move/copy change. 

Solves #134 