### PR TITLE
Forbid remove missing flag

### DIFF
--- a/src/main/java/com/flipkart/zjsonpatch/CompatibilityFlags.java
+++ b/src/main/java/com/flipkart/zjsonpatch/CompatibilityFlags.java
@@ -24,7 +24,8 @@ import java.util.EnumSet;
 public enum CompatibilityFlags {
     MISSING_VALUES_AS_NULLS,
     REMOVE_NONE_EXISTING_ARRAY_ELEMENT,
-    ALLOW_MISSING_TARGET_OBJECT_ON_REPLACE;
+    ALLOW_MISSING_TARGET_OBJECT_ON_REPLACE,
+    FORBID_REMOVE_MISSING_OBJECT;
 
     public static EnumSet<CompatibilityFlags> defaults() {
         return EnumSet.noneOf(CompatibilityFlags.class);

--- a/src/test/java/com/flipkart/zjsonpatch/CompatibilityTest.java
+++ b/src/test/java/com/flipkart/zjsonpatch/CompatibilityTest.java
@@ -92,4 +92,12 @@ public class CompatibilityTest {
         JsonNode source = mapper.readTree("{\"a\": true}");
         JsonPatch.apply(removeNode, source, EnumSet.of(FORBID_REMOVE_MISSING_OBJECT));
     }
+
+    @Test
+    public void withFlagRemoveShouldRemove() throws Exception {
+        JsonNode source = mapper.readTree("{\"b\": true}");
+        JsonNode expected = mapper.readTree("{}");
+        JsonNode result = JsonPatch.apply(removeNode, source, EnumSet.of(FORBID_REMOVE_MISSING_OBJECT));
+        assertThat(result, equalTo(expected));
+    }
 }

--- a/src/test/java/com/flipkart/zjsonpatch/CompatibilityTest.java
+++ b/src/test/java/com/flipkart/zjsonpatch/CompatibilityTest.java
@@ -35,6 +35,7 @@ public class CompatibilityTest {
     JsonNode replaceNodeWithMissingValue;
     JsonNode removeNoneExistingArrayElement;
     JsonNode replaceNode;
+    JsonNode removeNode;
 
     @Before
     public void setUp() throws Exception {
@@ -43,6 +44,7 @@ public class CompatibilityTest {
         replaceNodeWithMissingValue = mapper.readTree("[{\"op\":\"replace\",\"path\":\"/a\"}]");
         removeNoneExistingArrayElement = mapper.readTree("[{\"op\": \"remove\",\"path\": \"/b/0\"}]");
         replaceNode = mapper.readTree("[{\"op\":\"replace\",\"path\":\"/a\",\"value\":true}]");
+        removeNode = mapper.readTree("[{\"op\":\"remove\",\"path\":\"/b\"}]");
     }
 
     @Test
@@ -83,5 +85,11 @@ public class CompatibilityTest {
         JsonNode expected = mapper.readTree("{\"a\": true}");
         JsonNode result = JsonPatch.apply(replaceNode, mapper.createObjectNode(), EnumSet.of(ALLOW_MISSING_TARGET_OBJECT_ON_REPLACE));
         assertThat(result, equalTo(expected));
+    }
+
+    @Test(expected = JsonPatchApplicationException.class)
+    public void withFlagRemoveMissingValueShouldThrow() throws Exception {
+        JsonNode source = mapper.readTree("{\"a\": true}");
+        JsonPatch.apply(removeNode, source, EnumSet.of(FORBID_REMOVE_MISSING_OBJECT));
     }
 }


### PR DESCRIPTION
When applying a `remove` operation, the target value must exist https://datatracker.ietf.org/doc/html/rfc6902#section-4.2.

This adds a compatibility flag which must be enabled to enforce this behaviour (to maintain compatibility by default with previous versions).

I've also fixed a couple of places where the `JsonPatchApplicationException` contained the wrong information.