### PR TITLE
Make JsonPointer and Operation public

### DIFF
--- a/src/main/java/com/flipkart/zjsonpatch/JsonPointer.java
+++ b/src/main/java/com/flipkart/zjsonpatch/JsonPointer.java
@@ -38,7 +38,7 @@ import java.util.regex.Pattern;
  *
  * @since 0.4.8
  */
-class JsonPointer {
+public class JsonPointer {
     private final RefToken[] tokens;
 
     /** A JSON pointer representing the root node of a JSON document */

--- a/src/main/java/com/flipkart/zjsonpatch/Operation.java
+++ b/src/main/java/com/flipkart/zjsonpatch/Operation.java
@@ -24,7 +24,7 @@ import java.util.Map;
  * User: gopi.vishwakarma
  * Date: 30/07/14
  */
-enum Operation {
+public enum Operation {
     ADD("add"),
     REMOVE("remove"),
     REPLACE("replace"),


### PR DESCRIPTION
Why?
In https://github.com/flipkart-incubator/zjsonpatch/pull/168 I introduced get methods for the fields of the `JsonPatchApplicationException`. Unfortunately the classes JsonPointer and Operation are not public, so they are not visible when using the getMethods in the project, where I wanna use this library.

What?
add public modifier to JsonPointer and Operation