### PR TITLE
GH-139: Allow pointing to array elements via a reference field

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
 - It can be used to avoid sending a whole document when only a part has changed, thus reducing network bandwidth requirements if data (in JSON format) is required to send across multiple systems over network or in case of multi DC transfer.
 - When used in combination with the HTTP PATCH method as per [RFC 5789 HTTP PATCH](https://datatracker.ietf.org/doc/html/rfc5789), it will do partial updates for HTTP APIs in a standard way.
 - Extended JSON pointer functionality (i.e. reference array elements via a key): `/array/id=123/data`
+  - The user has to ensure that a unique field is used as a reference key. Should there be more than one array 
+    element matching the given key-value pair, the first element will be selected.
+  - Key based referencing may be slow for large arrays. Hence, standard index based array pointers should be used for large arrays. 
 
 
 ### Compatible with : Java 7+ versions

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 [![CircleCI](https://circleci.com/gh/flipkart-incubator/zjsonpatch/tree/master.svg?style=svg)](https://circleci.com/gh/flipkart-incubator/zjsonpatch/tree/master) [![Join the chat at https://gitter.im/zjsonpatch/community](https://badges.gitter.im/zjsonpatch/community.svg)](https://gitter.im/zjsonpatch/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) 
 
-# This is an implementation of  [RFC 6902 JSON Patch](https://datatracker.ietf.org/doc/html/rfc6902) written in Java.
+# This is an implementation of [RFC 6902 JSON Patch](https://datatracker.ietf.org/doc/html/rfc6902) written in Java with extended JSON pointer.
 
 ## Description & Use-Cases
 - Java Library to find / apply JSON Patches according to [RFC 6902](https://datatracker.ietf.org/doc/html/rfc6902).
 - JSON Patch defines a JSON document structure for representing changes to a JSON document.
 - It can be used to avoid sending a whole document when only a part has changed, thus reducing network bandwidth requirements if data (in JSON format) is required to send across multiple systems over network or in case of multi DC transfer.
-- When used in combination with the HTTP PATCH method as per [RFC 5789 HTTP PATCH](https://datatracker.ietf.org/doc/html/rfc5789), it will do partial updates for HTTP APIs in a standard  way.
+- When used in combination with the HTTP PATCH method as per [RFC 5789 HTTP PATCH](https://datatracker.ietf.org/doc/html/rfc5789), it will do partial updates for HTTP APIs in a standard way.
+- Extended JSON pointer functionality (i.e. reference array elements via a key): `/array/id=123/data`
 
 
 ### Compatible with : Java 7+ versions
@@ -17,7 +18,7 @@ Package      |	Class, % 	 |  Method, % 	   |  Line, %           |
 all classes  |	100% (6/ 6)  |	93.6% (44/ 47) |  96.2% (332/ 345)  |
 
 ## Complexity
-- To find JsonPatch : Ω(N+M) ,N and M represents number of keys in first and second json respectively / O(summation of la*lb) where la , lb represents JSON array of length la / lb of against same key in first and second JSON ,since LCS is used to find difference between 2 JSON arrays there of order of quadratic.
+- To find JsonPatch : Ω(N+M), N and M represents number of keys in first and second json respectively / O(summation of la*lb) where la , lb represents JSON array of length la / lb of against same key in first and second JSON ,since LCS is used to find difference between 2 JSON arrays there of order of quadratic.
 - To Optimize Diffs ( compact move and remove into Move ) : Ω(D) / O(D*D) where D represents number of diffs obtained before compaction into Move operation.
 - To Apply Diff : O(D) where D represents number of diffs
 
@@ -78,6 +79,33 @@ Following patch will be returned:
 [{"op":"move","from":"/a","path":"/b/2"}]
 ```
 here `"op"` specifies the operation (`"move"`), `"from"` specifies the path from where the value should be moved, and  `"path"` specifies where value should be moved. The value that is moved is taken as the content at the `"from"` path.
+
+### Extended JSON Pointer Example
+JSON
+```json
+{
+  "a": [
+    {
+      "id": 1,
+      "data": "abc"
+    },
+    {
+      "id": 2,
+      "data": "def"
+    }
+  ]
+}
+```
+
+JSON path
+```jsonpath
+/a/id=2/data
+```
+
+Following JSON would be returned
+```json
+"def"
+```
 
 ### Apply Json Patch In-Place
 ```xml

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.flipkart.zjsonpatch</groupId>
     <artifactId>zjsonpatch</artifactId>
-    <version>0.4.17-SNAPSHOT</version>
+    <version>0.5.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>zjsonpatch</name>

--- a/src/main/java/com/flipkart/zjsonpatch/JsonDiff.java
+++ b/src/main/java/com/flipkart/zjsonpatch/JsonDiff.java
@@ -269,7 +269,7 @@ public final class JsonDiff {
             int value = counters.get(i);
             if (value != 0) {
                 int currValue = tokens.get(i).getIndex();
-                tokens.set(i, new JsonPointer.RefToken(Integer.toString(currValue + value)));
+                tokens.set(i, JsonPointer.RefToken.parse(Integer.toString(currValue + value)));
             }
         }
         return new JsonPointer(tokens);

--- a/src/main/java/com/flipkart/zjsonpatch/JsonPointer.java
+++ b/src/main/java/com/flipkart/zjsonpatch/JsonPointer.java
@@ -242,7 +242,7 @@ public class JsonPointer {
                     JsonNode foundArrayNode = null;
                     for (int arrayIdx = 0; arrayIdx < current.size(); ++arrayIdx) {
                         JsonNode arrayNode = current.get(arrayIdx);
-                        if (arrayNode.has(keyRef.key) && Objects.equals(keyRef.value, arrayNode.get(keyRef.key).textValue())) {
+                        if (matches(keyRef, arrayNode)) {
                             foundArrayNode = arrayNode;
                             break;
                         }
@@ -267,6 +267,19 @@ public class JsonPointer {
         return current;
     }
 
+    private boolean matches(KeyRef keyRef, JsonNode arrayNode) {
+        boolean matches = false;
+        if (arrayNode.has(keyRef.key)) {
+             JsonNode valueNode = arrayNode.get(keyRef.key);
+             if (valueNode.isTextual()) {
+                 matches = Objects.equals(keyRef.value, valueNode.textValue());
+             } else if (valueNode.isNumber() || valueNode.isBoolean()) {
+                 matches = Objects.equals(keyRef.value, valueNode.toString());
+             }
+        }
+        return matches;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -285,7 +298,7 @@ public class JsonPointer {
 
     /** Represents a single JSON Pointer reference token. */
     static class RefToken {
-        private String decodedToken;
+        private final String decodedToken;
         private final Integer index;
         private final KeyRef keyRef;
 

--- a/src/test/java/com/flipkart/zjsonpatch/JsonPointerTest.java
+++ b/src/test/java/com/flipkart/zjsonpatch/JsonPointerTest.java
@@ -28,12 +28,21 @@ public class JsonPointerTest {
     }
 
     @Test
-    public void parsesArrayIndirection() {
+    public void parsesArrayIndexIndirection() {
         JsonPointer parsed = JsonPointer.parse("/0");
         assertFalse(parsed.isRoot());
         assertEquals(1, parsed.size());
         assertTrue(parsed.get(0).isArrayIndex());
         assertEquals(0, parsed.get(0).getIndex());
+    }
+
+    @Test
+    public void parsesArrayKeyRefIndirection() {
+        JsonPointer parsed = JsonPointer.parse("/id=ID_1");
+        assertFalse(parsed.isRoot());
+        assertEquals(1, parsed.size());
+        assertTrue(parsed.get(0).isArrayKeyRef());
+        assertEquals(new JsonPointer.KeyRef("id", "ID_1"), parsed.get(0).getKeyRef());
     }
 
     @Test
@@ -94,9 +103,9 @@ public class JsonPointerTest {
 
     @Test
     public void parsesMixedIndirections() {
-        JsonPointer parsed = JsonPointer.parse("/0/a/1/b");
+        JsonPointer parsed = JsonPointer.parse("/0/a/1/b/id=2/c");
         assertFalse(parsed.isRoot());
-        assertEquals(4, parsed.size());
+        assertEquals(6, parsed.size());
         assertTrue(parsed.get(0).isArrayIndex());
         assertEquals(0, parsed.get(0).getIndex());
         assertFalse(parsed.get(1).isArrayIndex());
@@ -105,6 +114,12 @@ public class JsonPointerTest {
         assertEquals(1, parsed.get(2).getIndex());
         assertFalse(parsed.get(3).isArrayIndex());
         assertEquals("b", parsed.get(3).getField());
+        assertFalse(parsed.get(4).isArrayIndex());
+        assertTrue(parsed.get(4).isArrayKeyRef());
+        assertEquals(new JsonPointer.KeyRef("id", "2"), parsed.get(4).getKeyRef());
+        assertFalse(parsed.get(5).isArrayIndex());
+        assertFalse(parsed.get(5).isArrayKeyRef());
+        assertEquals("c", parsed.get(5).getField());
     }
 
     @Test
@@ -125,6 +140,15 @@ public class JsonPointerTest {
         assertEquals("/", parsed.get(0).getField());
     }
 
+    @Test
+    public void parsesEscapedEqualsSign() {
+        JsonPointer parsed = JsonPointer.parse("/~2");
+        assertFalse(parsed.isRoot());
+        assertEquals(1, parsed.size());
+        assertFalse(parsed.get(0).isArrayIndex());
+        assertEquals("=", parsed.get(0).getField());
+    }
+
     // Parsing error conditions --
 
     @Test(expected = IllegalArgumentException.class)
@@ -134,7 +158,7 @@ public class JsonPointerTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void throwsOnInvalidEscapedSequence1() {
-        JsonPointer.parse("/~2");
+        JsonPointer.parse("/~3");
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -165,6 +189,27 @@ public class JsonPointerTest {
         assertEquals(om.readTree("8"), JsonPointer.parse("/m~0n").evaluate(testData));
     }
 
+    @Test
+    public void evaluatesWithKeyReferences() throws IOException, JsonPointerEvaluationException {
+        ObjectMapper om = TestUtils.DEFAULT_MAPPER;
+        JsonNode data = TestUtils.loadResourceAsJsonNode("/testdata/json-pointer-key-refs.json");
+        JsonNode testData = data.get("testData");
+
+        assertEquals(om.readTree("{\"id\": \"ID_1\",\"some\": \"data_1\"}"), JsonPointer.parse("/objArray/id=ID_1").evaluate(testData));
+        assertEquals(om.readTree("\"data_1\""), JsonPointer.parse("/objArray/id=ID_1/some").evaluate(testData));
+        assertEquals(om.readTree("\"data_2\""), JsonPointer.parse("/objArray/id=ID_2/some").evaluate(testData));
+        assertEquals(om.readTree("\"some_more\""), JsonPointer.parse("/objArray/id=ID_2/and").evaluate(testData));
+        assertEquals(om.readTree("7"), JsonPointer.parse("/objArray/id=ID_2/num").evaluate(testData));
+        assertEquals(om.readTree("\"data_2\""), JsonPointer.parse("/objArray/and=some_more/some").evaluate(testData));
+        assertEquals(om.readTree("\"data_3\""), JsonPointer.parse("/objArray/id=ID_3/some").evaluate(testData));
+        assertEquals(om.readTree("\"data_4\""), JsonPointer.parse("/objArray/id=ID_4/some").evaluate(testData));
+        assertEquals(om.readTree("\"data_4\""), JsonPointer.parse("/objArray/3/some").evaluate(testData));
+
+        assertThrows(JsonPointerEvaluationException.class, () -> JsonPointer.parse("/objArray/id=ID_5").evaluate(testData));
+        assertThrows(JsonPointerEvaluationException.class, () -> JsonPointer.parse("/objArray/ref=REF").evaluate(testData));
+        assertThrows(JsonPointerEvaluationException.class, () -> JsonPointer.parse("/objArray/4").evaluate(testData));
+    }
+
     // Utility methods --
 
     @Test
@@ -185,6 +230,8 @@ public class JsonPointerTest {
         assertEquals("/k\"l", JsonPointer.parse("/k\"l").toString());
         assertEquals("/ ", JsonPointer.parse("/ ").toString());
         assertEquals("/m~0n", JsonPointer.parse("/m~0n").toString());
+        assertEquals("/m=n", JsonPointer.parse("/m=n").toString());
+        assertEquals("/m~2n", JsonPointer.parse("/m~2n").toString());
     }
 }
 

--- a/src/test/resources/testdata/json-pointer-key-refs.json
+++ b/src/test/resources/testdata/json-pointer-key-refs.json
@@ -1,0 +1,26 @@
+{
+  "testData": {
+    "objArray": [
+      {
+        "id": "ID_1",
+        "some": "data_1"
+      },
+      {
+        "id": "ID_2",
+        "some": "data_2",
+        "and": "some_more",
+        "num": 7
+      },
+      {
+        "id": "ID_3",
+        "some": "data_3",
+        "and": "some_more"
+      },
+      {
+        "id": "ID_4",
+        "some": "data_4",
+        "and": "some_more"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
https://github.com/flipkart-incubator/zjsonpatch/issues/139: 

Allow pointing to array elements via a reference field

Example path `/array/id=123/data`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added support for extended JSON Pointer syntax, allowing array elements to be referenced by key-value pairs (e.g., `/array/id=123/data`).
  - Enhanced escape sequence handling in JSON Pointer paths, including support for `~2` as a literal equals sign.
- **Documentation**
  - Updated README to describe the new extended JSON Pointer feature and provide usage examples.
- **Tests**
  - Added and expanded tests to verify parsing, evaluation, and escaping for the new array key reference syntax.
  - Introduced new test data for key reference scenarios.
- **Chores**
  - Updated project version to `0.5.0-SNAPSHOT`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->